### PR TITLE
Set JarURLConnection.useCaches to false in Compiler.isOutDated().

### DIFF
--- a/src/main/java/org/glassfish/wasp/compiler/Compiler.java
+++ b/src/main/java/org/glassfish/wasp/compiler/Compiler.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -551,6 +552,7 @@ public class Compiler {
                 URLConnection includeUconn = includeUrl.openConnection();
                 long includeLastModified = 0;
                 if (includeUconn instanceof JarURLConnection) {
+                    includeUconn.setUseCaches(false);
                     includeLastModified = ((JarURLConnection) includeUconn).getJarEntry().getTime();
                 } else {
                     includeLastModified = includeUconn.getLastModified();


### PR DESCRIPTION
* Follow up https://github.com/javaee/javaee-jsp-api/commit/454d89f39784e8b6d9a111d9b30e617462efa404.  
    
The jar file included in the JSP application remains locked if `JarURLConnection.useCaches` is true when the connection is closed.  
https://github.com/openjdk/jdk/blob/739769c8fc4b496f08a92225a12d07414537b6c0/src/java.base/share/classes/sun/net/www/protocol/jar/JarURLConnection.java#L105-#L118  
In Windows, user cannot remove the file until restarting JVM.  

Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>