### PR TITLE
Implement errorOnELNotFound

### DIFF
--- a/src/main/java/org/glassfish/wasp/compiler/Compiler.java
+++ b/src/main/java/org/glassfish/wasp/compiler/Compiler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -31,9 +32,9 @@ import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.glassfish.wasp.WaspException;
 import org.glassfish.wasp.JspCompilationContext;
 import org.glassfish.wasp.Options;
+import org.glassfish.wasp.WaspException;
 import org.glassfish.wasp.servlet.JspServletWrapper;
 
 /**
@@ -126,6 +127,11 @@ public class Compiler {
         pageInfo.setELIgnored(JspUtil.booleanValue(jspProperty.isELIgnored()));
         pageInfo.setScriptingInvalid(JspUtil.booleanValue(jspProperty.isScriptingInvalid()));
         pageInfo.setTrimDirectiveWhitespaces(JspUtil.booleanValue(jspProperty.getTrimSpaces()));
+
+        if (jspProperty.getErrorOnELNotFound() != null) {
+            pageInfo.setErrorOnELNotFound(JspUtil.booleanValue(jspProperty.getErrorOnELNotFound()));
+        }
+
         pageInfo.setDeferredSyntaxAllowedAsLiteral(JspUtil.booleanValue(jspProperty.getPoundAllowed()));
         pageInfo.setErrorOnUndeclaredNamespace(JspUtil.booleanValue(jspProperty.errorOnUndeclaredNamespace()));
 

--- a/src/main/java/org/glassfish/wasp/compiler/Generator.java
+++ b/src/main/java/org/glassfish/wasp/compiler/Generator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -33,8 +34,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.glassfish.wasp.Constants;
-import org.glassfish.wasp.WaspException;
 import org.glassfish.wasp.JspCompilationContext;
+import org.glassfish.wasp.WaspException;
 import org.glassfish.wasp.runtime.JspRuntimeLibrary;
 import org.xml.sax.Attributes;
 
@@ -431,6 +432,17 @@ class Generator {
         out.printil("}");
         out.println();
 
+        out.printil("public boolean getErrorOnELNotFound() {");
+        out.pushIndent();
+        if (pageInfo.isErrorOnELNotFound()) {
+            out.printil("return true;");
+        } else {
+            out.printil("return false;");
+        }
+        out.popIndent();
+        out.printil("}");
+        out.println();
+
         // Method to get bytes from String
         if (genBytes) {
             out.printil("private static byte[] _jspx_getBytes(String s) {");
@@ -490,10 +502,6 @@ class Generator {
         out.print(" extends ");
         out.println(pageInfo.getExtends());
         out.printin("    implements org.glassfish.wasp.runtime.JspSourceDependent");
-        if (!pageInfo.isThreadSafe()) {
-            out.println(",");
-            out.printin("                 SingleThreadModel");
-        }
         out.println(" {");
         out.pushIndent();
 
@@ -3326,9 +3334,9 @@ class Generator {
             out.println(");");
         }
         if (aliasSeen) {
-            out.printil("this.jspContext = new org.glassfish.wasp.runtime.JspContextWrapper(ctx, _jspx_nested, _jspx_at_begin, _jspx_at_end, aliasMap);");
+            out.printil("this.jspContext = new org.glassfish.wasp.runtime.JspContextWrapper(this, ctx, _jspx_nested, _jspx_at_begin, _jspx_at_end, aliasMap);");
         } else {
-            out.printil("this.jspContext = new org.glassfish.wasp.runtime.JspContextWrapper(ctx, _jspx_nested, _jspx_at_begin, _jspx_at_end, null);");
+            out.printil("this.jspContext = new org.glassfish.wasp.runtime.JspContextWrapper(this, ctx, _jspx_nested, _jspx_at_begin, _jspx_at_end, null);");
         }
         out.popIndent();
         out.printil("}");

--- a/src/main/java/org/glassfish/wasp/compiler/JspConfig.java
+++ b/src/main/java/org/glassfish/wasp/compiler/JspConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -44,10 +45,11 @@ public class JspConfig {
     private ServletContext ctxt;
     private boolean initialized = false;
 
-    private String defaultIsXml = null; // unspecified
-    private String defaultIsELIgnored = null; // unspecified
+    private String defaultIsXml; // unspecified
+    private String defaultIsELIgnored; // unspecified
     private String defaultIsScriptingInvalid = "false";
     private String defaultTrimSpaces = "false";
+    private String defaultErrorOnELNotFound = "false";
     private String defaultPoundAllowed = "false";
     private String defaultErrorOnUndeclaredNamespace = "false";
     private JspProperty defaultJspProperty;
@@ -72,6 +74,7 @@ public class JspConfig {
             String elIgnored = jpg.getElIgnored();
             String isXml = jpg.getIsXml();
             String trimSpaces = jpg.getTrimDirectiveWhitespaces();
+            String errorOnELNotFound = jpg.getErrorOnELNotFound();
             String poundAllowed = jpg.getDeferredSyntaxAllowedAsLiteral();
             String buffer = jpg.getBuffer();
             String defaultContentType = jpg.getDefaultContentType();
@@ -121,8 +124,20 @@ public class JspConfig {
                     }
                 }
 
-                JspProperty property = new JspProperty(isXml, elIgnored, scriptingInvalid, trimSpaces, poundAllowed, pageEncoding, includePrelude, includeCoda,
-                        defaultContentType, buffer, errorOnUndeclaredNamespace);
+                JspProperty property = new JspProperty(
+                        isXml,
+                        elIgnored,
+                        scriptingInvalid,
+                        trimSpaces,
+                        errorOnELNotFound,
+                        poundAllowed,
+                        pageEncoding,
+                        includePrelude,
+                        includeCoda,
+                        defaultContentType,
+                        buffer,
+                        errorOnUndeclaredNamespace);
+
                 JspPropertyGroup propertyGroup = new JspPropertyGroup(path, extension, property);
 
                 jspProperties.add(propertyGroup);
@@ -131,7 +146,6 @@ public class JspConfig {
     }
 
     private synchronized void init() throws WaspException {
-
         if (!initialized) {
 
             processWebDotXml(ctxt);
@@ -140,8 +154,17 @@ public class JspConfig {
                 defaultIsELIgnored = "true";
             }
 
-            defaultJspProperty = new JspProperty(defaultIsXml, defaultIsELIgnored, defaultIsScriptingInvalid, defaultTrimSpaces, defaultPoundAllowed, null,
-                    null, null, null, null, defaultErrorOnUndeclaredNamespace);
+            defaultJspProperty =
+                new JspProperty(
+                    defaultIsXml,
+                    defaultIsELIgnored,
+                    defaultIsScriptingInvalid,
+                    defaultTrimSpaces,
+                    defaultErrorOnELNotFound,
+                    defaultPoundAllowed,
+                    null, null, null, null, null,
+                    defaultErrorOnUndeclaredNamespace);
+
             initialized = true;
         }
     }
@@ -212,6 +235,7 @@ public class JspConfig {
         JspPropertyGroup elIgnoredMatch = null;
         JspPropertyGroup scriptingInvalidMatch = null;
         JspPropertyGroup trimSpacesMatch = null;
+        JspPropertyGroup errorOnELNotFoundMatch = null;
         JspPropertyGroup poundAllowedMatch = null;
         JspPropertyGroup pageEncodingMatch = null;
         JspPropertyGroup defaultContentTypeMatch = null;
@@ -269,6 +293,9 @@ public class JspConfig {
             if (jp.getTrimSpaces() != null) {
                 trimSpacesMatch = selectProperty(trimSpacesMatch, jpg);
             }
+            if (jp.getErrorOnELNotFound() != null) {
+                errorOnELNotFoundMatch = selectProperty(errorOnELNotFoundMatch, jpg);
+            }
             if (jp.getPoundAllowed() != null) {
                 poundAllowedMatch = selectProperty(poundAllowedMatch, jpg);
             }
@@ -287,6 +314,7 @@ public class JspConfig {
         String isELIgnored = defaultIsELIgnored;
         String isScriptingInvalid = defaultIsScriptingInvalid;
         String trimSpaces = defaultTrimSpaces;
+        String errorOnELNotFound = defaultErrorOnELNotFound;
         String poundAllowed = defaultPoundAllowed;
         String pageEncoding = null;
         String defaultContentType = null;
@@ -305,6 +333,9 @@ public class JspConfig {
         if (trimSpacesMatch != null) {
             trimSpaces = trimSpacesMatch.getJspProperty().getTrimSpaces();
         }
+        if (errorOnELNotFoundMatch != null) {
+            errorOnELNotFound = errorOnELNotFoundMatch.getJspProperty().getErrorOnELNotFound();
+        }
         if (poundAllowedMatch != null) {
             poundAllowed = poundAllowedMatch.getJspProperty().getPoundAllowed();
         }
@@ -321,8 +352,19 @@ public class JspConfig {
             errorOnUndeclaredNamespace = errorOnUndeclaredNamespaceMatch.getJspProperty().errorOnUndeclaredNamespace();
         }
 
-        return new JspProperty(isXml, isELIgnored, isScriptingInvalid, trimSpaces, poundAllowed, pageEncoding, includePreludes, includeCodas,
-                defaultContentType, buffer, errorOnUndeclaredNamespace);
+        return new JspProperty(
+                isXml,
+                isELIgnored,
+                isScriptingInvalid,
+                trimSpaces,
+                errorOnELNotFound,
+                poundAllowed,
+                pageEncoding,
+                includePreludes,
+                includeCodas,
+                defaultContentType,
+                buffer,
+                errorOnUndeclaredNamespace);
     }
 
     /**

--- a/src/main/java/org/glassfish/wasp/compiler/JspProperty.java
+++ b/src/main/java/org/glassfish/wasp/compiler/JspProperty.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -26,6 +27,7 @@ public class JspProperty {
     private String scriptingInvalid;
     private String pageEncoding;
     private String trimSpaces;
+    private String errorOnELNotFound;
     private String poundAllowed;
     private List<String> includePrelude;
     private List<String> includeCoda;
@@ -33,13 +35,14 @@ public class JspProperty {
     private String defaultContentType;
     private String errorOnUndeclaredNamespace;
 
-    public JspProperty(String isXml, String elIgnored, String scriptingInvalid, String trimSpaces, String poundAllowed, String pageEncoding,
+    public JspProperty(String isXml, String elIgnored, String scriptingInvalid, String trimSpaces, String errorOnELNotFound, String poundAllowed, String pageEncoding,
             List<String> includePrelude, List<String> includeCoda, String defaultContentType, String buffer, String errorOnUndeclaredNamespace) {
 
         this.isXml = isXml;
         this.elIgnored = elIgnored;
         this.scriptingInvalid = scriptingInvalid;
         this.trimSpaces = trimSpaces;
+        this.errorOnELNotFound = errorOnELNotFound;
         this.poundAllowed = poundAllowed;
         this.pageEncoding = pageEncoding;
         this.includePrelude = includePrelude;
@@ -67,6 +70,10 @@ public class JspProperty {
 
     public String getTrimSpaces() {
         return trimSpaces;
+    }
+
+    public String getErrorOnELNotFound() {
+        return errorOnELNotFound;
     }
 
     public String getPoundAllowed() {

--- a/src/main/java/org/glassfish/wasp/compiler/JspPropertyGroup.java
+++ b/src/main/java/org/glassfish/wasp/compiler/JspPropertyGroup.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -40,4 +41,5 @@ public class JspPropertyGroup {
     public JspProperty getJspProperty() {
         return jspProperty;
     }
+
 }

--- a/src/main/java/org/glassfish/wasp/compiler/PageInfo.java
+++ b/src/main/java/org/glassfish/wasp/compiler/PageInfo.java
@@ -55,7 +55,7 @@ public class PageInfo {
     private String language;
     private String defaultExtends = Constants.JSP_SERVLET_BASE;
     private String xtends;
-    private String contentType = null;
+    private String contentType;
     private String session;
     private boolean isSession = true;
     private String bufferValue;
@@ -65,31 +65,31 @@ public class PageInfo {
     private String isThreadSafeValue;
     private boolean isThreadSafe = true;
     private String isErrorPageValue;
-    private boolean isErrorPage = false;
-    private String errorPage = null;
+    private boolean isErrorPage;
+    private String errorPage;
     private String info;
 
     private int maxTagNesting = 0;
-    private boolean scriptless = false;
-    private boolean scriptingInvalid = false;
+    private boolean scriptless;
+    private boolean scriptingInvalid;
     private String isELIgnoredValue;
-    private boolean isELIgnored = false;
-    private String omitXmlDecl = null;
-    private String doctypeName = null;
-    private String doctypePublic = null;
-    private String doctypeSystem = null;
+    private boolean isELIgnored;
+    private String omitXmlDecl;
+    private String doctypeName;
+    private String doctypePublic;
+    private String doctypeSystem;
     private String deferredSyntaxAllowedAsLiteralValue;
-    private boolean deferredSyntaxAllowedAsLiteral = false;
+    private boolean deferredSyntaxAllowedAsLiteral;
     private String trimDirectiveWhitespacesValue;
-    private boolean trimDirectiveWhitespaces = false;
-    private boolean errorOnUndeclaredNamespace = false;
+    private boolean trimDirectiveWhitespaces;
+    private boolean errorOnUndeclaredNamespace;
 
     private boolean isJspPrefixHijacked;
 
     // Set of all element and attribute prefixes used in this translation unit
     private HashSet<String> prefixes;
 
-    private boolean hasJspRoot = false;
+    private boolean hasJspRoot;
     private List<String> includePrelude;
     private List<String> includeCoda;
     private List<String> pluginDcls; // Id's for tagplugin declarations
@@ -98,7 +98,6 @@ public class PageInfo {
     private String rootPath;
 
     PageInfo(BeanRepository beanRepository, String jspFile) {
-
         this.jspFile = jspFile;
         this.beanRepository = beanRepository;
         this.taglibsMap = new HashMap<>();
@@ -147,9 +146,9 @@ public class PageInfo {
         return jspFile;
     }
 
-    public void addDependant(String d) {
-        if (!dependants.contains(d) && !jspFile.equals(d)) {
-            dependants.add(d);
+    public void addDependant(String dependant) {
+        if (!dependants.contains(dependant) && !jspFile.equals(dependant)) {
+            dependants.add(dependant);
         }
     }
 
@@ -169,16 +168,16 @@ public class PageInfo {
         this.maxTagNesting = maxTagNesting;
     }
 
-    public void setScriptless(boolean s) {
-        scriptless = s;
+    public void setScriptless(boolean scriptless) {
+        this.scriptless = scriptless;
     }
 
     public boolean isScriptless() {
         return scriptless;
     }
 
-    public void setScriptingInvalid(boolean s) {
-        scriptingInvalid = s;
+    public void setScriptingInvalid(boolean scriptingInvalid) {
+        this.scriptingInvalid = scriptingInvalid;
     }
 
     public boolean isScriptingInvalid() {
@@ -359,7 +358,6 @@ public class PageInfo {
      * @return The URI to which the given prefix maps
      */
     public String getURI(String prefix) {
-
         String uri = null;
 
         LinkedList<String> stack = xmlPrefixMapper.get(prefix);
@@ -377,13 +375,12 @@ public class PageInfo {
     /*
      * language
      */
-    public void setLanguage(String value, Node n, ErrorDispatcher err, boolean pagedir) throws WaspException {
-
+    public void setLanguage(String value, Node node, ErrorDispatcher err, boolean pagedir) throws WaspException {
         if (!"java".equalsIgnoreCase(value)) {
             if (pagedir) {
-                err.jspError(n, "jsp.error.page.language.nonjava");
+                err.jspError(node, "jsp.error.page.language.nonjava");
             } else {
-                err.jspError(n, "jsp.error.tag.language.nonjava");
+                err.jspError(node, "jsp.error.tag.language.nonjava");
             }
         }
 
@@ -401,8 +398,7 @@ public class PageInfo {
     /*
      * extends
      */
-    public void setExtends(String value, Node.PageDirective n) {
-
+    public void setExtends(String value, Node.PageDirective pageDirective) {
         xtends = value;
 
         /*
@@ -410,7 +406,7 @@ public class PageInfo {
          * will assume the extended class is in the same pkg as the generated servlet.
          */
         if (value.indexOf('.') < 0) {
-            n.addImport(value);
+            pageDirective.addImport(value);
         }
     }
 
@@ -451,26 +447,24 @@ public class PageInfo {
     /*
      * buffer
      */
-    public void setBufferValue(String value, Node n, ErrorDispatcher err) throws WaspException {
-
+    public void setBufferValue(String value, Node node, ErrorDispatcher err) throws WaspException {
         if ("none".equalsIgnoreCase(value)) {
             buffer = 0;
         } else {
             if (value == null || !value.endsWith("kb")) {
-                if (n == null) {
+                if (node == null) {
                     err.jspError("jsp.error.jspproperty.invalid.buffer");
                 } else {
-                    err.jspError(n, "jsp.error.page.invalid.buffer");
+                    err.jspError(node, "jsp.error.page.invalid.buffer");
                 }
             }
             try {
-                Integer k = new Integer(value.substring(0, value.length() - 2));
-                buffer = k.intValue() * 1024;
+                buffer = Integer.parseInt(value.substring(0, value.length() - 2)) * 1024;
             } catch (NumberFormatException e) {
-                if (n == null) {
+                if (node == null) {
                     err.jspError("jsp.error.jspproperty.invalid.buffer");
                 } else {
-                    err.jspError(n, "jsp.error.page.invalid.buffer");
+                    err.jspError(node, "jsp.error.page.invalid.buffer");
                 }
             }
         }
@@ -493,14 +487,13 @@ public class PageInfo {
     /*
      * session
      */
-    public void setSession(String value, Node n, ErrorDispatcher err) throws WaspException {
-
+    public void setSession(String value, Node node, ErrorDispatcher err) throws WaspException {
         if ("true".equalsIgnoreCase(value)) {
             isSession = true;
         } else if ("false".equalsIgnoreCase(value)) {
             isSession = false;
         } else {
-            err.jspError(n, "jsp.error.page.invalid.session");
+            err.jspError(node, "jsp.error.page.invalid.session");
         }
 
         session = value;
@@ -517,14 +510,13 @@ public class PageInfo {
     /*
      * autoFlush
      */
-    public void setAutoFlush(String value, Node n, ErrorDispatcher err) throws WaspException {
-
+    public void setAutoFlush(String value, Node node, ErrorDispatcher err) throws WaspException {
         if ("true".equalsIgnoreCase(value)) {
             isAutoFlush = true;
         } else if ("false".equalsIgnoreCase(value)) {
             isAutoFlush = false;
         } else {
-            err.jspError(n, "jsp.error.autoFlush.invalid");
+            err.jspError(node, "jsp.error.autoFlush.invalid");
         }
 
         autoFlush = value;
@@ -541,14 +533,13 @@ public class PageInfo {
     /*
      * isThreadSafe
      */
-    public void setIsThreadSafe(String value, Node n, ErrorDispatcher err) throws WaspException {
-
+    public void setIsThreadSafe(String value, Node node, ErrorDispatcher err) throws WaspException {
         if ("true".equalsIgnoreCase(value)) {
             isThreadSafe = true;
         } else if ("false".equalsIgnoreCase(value)) {
             isThreadSafe = false;
         } else {
-            err.jspError(n, "jsp.error.page.invalid.isthreadsafe");
+            err.jspError(node, "jsp.error.page.invalid.isthreadsafe");
         }
 
         isThreadSafeValue = value;
@@ -587,14 +578,13 @@ public class PageInfo {
     /*
      * isErrorPage
      */
-    public void setIsErrorPage(String value, Node n, ErrorDispatcher err) throws WaspException {
-
+    public void setIsErrorPage(String value, Node node, ErrorDispatcher err) throws WaspException {
         if ("true".equalsIgnoreCase(value)) {
             isErrorPage = true;
         } else if ("false".equalsIgnoreCase(value)) {
             isErrorPage = false;
         } else {
-            err.jspError(n, "jsp.error.page.invalid.iserrorpage");
+            err.jspError(node, "jsp.error.page.invalid.iserrorpage");
         }
 
         isErrorPageValue = value;
@@ -611,25 +601,24 @@ public class PageInfo {
     /*
      * isELIgnored
      */
-    public void setIsELIgnored(String value, Node n, ErrorDispatcher err, boolean pagedir) throws WaspException {
-
+    public void setIsELIgnored(String value, Node node, ErrorDispatcher err, boolean pagedir) throws WaspException {
         if ("true".equalsIgnoreCase(value)) {
             isELIgnored = true;
         } else if ("false".equalsIgnoreCase(value)) {
             isELIgnored = false;
         } else {
             if (pagedir) {
-                err.jspError(n, "jsp.error.page.invalid.iselignored");
+                err.jspError(node, "jsp.error.page.invalid.iselignored");
             } else {
-                err.jspError(n, "jsp.error.tag.invalid.iselignored");
+                err.jspError(node, "jsp.error.tag.invalid.iselignored");
             }
         }
 
         isELIgnoredValue = value;
     }
 
-    public void setELIgnored(boolean s) {
-        isELIgnored = s;
+    public void setELIgnored(boolean isELIgnored) {
+        this.isELIgnored = isELIgnored;
     }
 
     public String getIsELIgnored() {
@@ -643,25 +632,24 @@ public class PageInfo {
     /*
      * deferredSyntaxAllowedAsLiteral
      */
-    public void setDeferredSyntaxAllowedAsLiteral(String value, Node n, ErrorDispatcher err, boolean pagedir) throws WaspException {
-
+    public void setDeferredSyntaxAllowedAsLiteral(String value, Node node, ErrorDispatcher err, boolean pagedir) throws WaspException {
         if ("true".equalsIgnoreCase(value)) {
             deferredSyntaxAllowedAsLiteral = true;
         } else if ("false".equalsIgnoreCase(value)) {
             deferredSyntaxAllowedAsLiteral = false;
         } else {
             if (pagedir) {
-                err.jspError(n, "jsp.error.page.invalid.deferred");
+                err.jspError(node, "jsp.error.page.invalid.deferred");
             } else {
-                err.jspError(n, "jsp.error.tag.invalid.deferred");
+                err.jspError(node, "jsp.error.tag.invalid.deferred");
             }
         }
 
         deferredSyntaxAllowedAsLiteralValue = value;
     }
 
-    public void setDeferredSyntaxAllowedAsLiteral(boolean s) {
-        deferredSyntaxAllowedAsLiteral = s;
+    public void setDeferredSyntaxAllowedAsLiteral(boolean deferredSyntaxAllowedAsLiteral) {
+        this.deferredSyntaxAllowedAsLiteral = deferredSyntaxAllowedAsLiteral;
     }
 
     public String getDeferredSyntaxAllowedAsLiteral() {
@@ -675,17 +663,16 @@ public class PageInfo {
     /*
      * trimDirectiveWhitespaces
      */
-    public void setTrimDirectiveWhitespaces(String value, Node n, ErrorDispatcher err, boolean pagedir) throws WaspException {
-
+    public void setTrimDirectiveWhitespaces(String value, Node node, ErrorDispatcher err, boolean pagedir) throws WaspException {
         if ("true".equalsIgnoreCase(value)) {
             trimDirectiveWhitespaces = true;
         } else if ("false".equalsIgnoreCase(value)) {
             trimDirectiveWhitespaces = false;
         } else {
             if (pagedir) {
-                err.jspError(n, "jsp.error.page.invalid.trim");
+                err.jspError(node, "jsp.error.page.invalid.trim");
             } else {
-                err.jspError(n, "jsp.error.tag.invalid.trim");
+                err.jspError(node, "jsp.error.tag.invalid.trim");
             }
         }
 

--- a/src/main/java/org/glassfish/wasp/compiler/PageInfo.java
+++ b/src/main/java/org/glassfish/wasp/compiler/PageInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -82,6 +83,9 @@ public class PageInfo {
     private boolean deferredSyntaxAllowedAsLiteral;
     private String trimDirectiveWhitespacesValue;
     private boolean trimDirectiveWhitespaces;
+    private String errorOnELNotFoundValue;
+    private boolean errorOnELNotFound;
+
     private boolean errorOnUndeclaredNamespace;
 
     private boolean isJspPrefixHijacked;
@@ -689,6 +693,38 @@ public class PageInfo {
 
     public boolean isTrimDirectiveWhitespaces() {
         return trimDirectiveWhitespaces;
+    }
+
+
+    /*
+     * errorOnELNotFound
+     */
+    public void setErrorOnELNotFound(String value, Node node, ErrorDispatcher err, boolean pagedir) throws WaspException {
+        if ("true".equalsIgnoreCase(value)) {
+            errorOnELNotFound = true;
+        } else if ("false".equalsIgnoreCase(value)) {
+            errorOnELNotFound = false;
+        } else {
+            if (pagedir) {
+                err.jspError(node, "jsp.error.page.invalid.errorOnELNotFound");
+            } else {
+                err.jspError(node, "jsp.error.tag.invalid.errorOnELNotFound");
+            }
+        }
+
+        errorOnELNotFoundValue = value;
+    }
+
+    public void setErrorOnELNotFound(boolean errorOnELNotFound) {
+        this.errorOnELNotFound = errorOnELNotFound;
+    }
+
+    public String getErrorOnELNotFound() {
+        return errorOnELNotFoundValue;
+    }
+
+    public boolean isErrorOnELNotFound() {
+        return errorOnELNotFound;
     }
 
     public void setErrorOnUndeclaredNamespace(boolean s) {

--- a/src/main/java/org/glassfish/wasp/compiler/TagFileProcessor.java
+++ b/src/main/java/org/glassfish/wasp/compiler/TagFileProcessor.java
@@ -75,7 +75,8 @@ class TagFileProcessor {
                 new JspUtil.ValidAttribute("import"),
                 new JspUtil.ValidAttribute("isELIgnored"),
                 new JspUtil.ValidAttribute("deferredSyntaxAllowedAsLiteral"),
-                new JspUtil.ValidAttribute("trimDirectiveWhitespaces") };
+                new JspUtil.ValidAttribute("trimDirectiveWhitespaces"),
+                new JspUtil.ValidAttribute("errorOnELNotFound") };
 
         private static final JspUtil.ValidAttribute[] attributeDirectiveAttrs = { new JspUtil.ValidAttribute("name", true),
                 new JspUtil.ValidAttribute("required"),

--- a/src/main/java/org/glassfish/wasp/compiler/Validator.java
+++ b/src/main/java/org/glassfish/wasp/compiler/Validator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -76,7 +77,8 @@ class Validator {
                 new JspUtil.ValidAttribute("pageEncoding"),
                 new JspUtil.ValidAttribute("isELIgnored"),
                 new JspUtil.ValidAttribute("deferredSyntaxAllowedAsLiteral"),
-                new JspUtil.ValidAttribute("trimDirectiveWhitespaces") };
+                new JspUtil.ValidAttribute("trimDirectiveWhitespaces"),
+                new JspUtil.ValidAttribute("errorOnELNotFound") };
 
         private boolean pageEncodingSeen = false;
 
@@ -196,6 +198,13 @@ class Validator {
                     } else if (!pageInfo.getTrimDirectiveWhitespaces().equals(value)) {
                         err.jspError(n, "jsp.error.page.conflict.trim", pageInfo.getTrimDirectiveWhitespaces(), value);
                     }
+                } else if ("errorOnELNotFound".equals(attr)) {
+                    if (pageInfo.getErrorOnELNotFound() == null) {
+                        pageInfo.setErrorOnELNotFound(value, n, err, true);
+                    } else if (!pageInfo.getErrorOnELNotFound().equals(value)) {
+                        err.jspError(n, "jsp.error.page.conflict.errorOnELNotFound",
+                                pageInfo.getErrorOnELNotFound(), value);
+                    }
                 }
             }
 
@@ -277,6 +286,12 @@ class Validator {
                         pageInfo.setTrimDirectiveWhitespaces(value, n, err, false);
                     } else if (!pageInfo.getTrimDirectiveWhitespaces().equals(value)) {
                         err.jspError(n, "jsp.error.tag.conflict.trim", pageInfo.getTrimDirectiveWhitespaces(), value);
+                    }
+                } else if ("errorOnELNotFound".equals(attr)) {
+                    if (pageInfo.getErrorOnELNotFound() == null) {
+                        pageInfo.setErrorOnELNotFound(value, n, err, false);
+                    } else if (!pageInfo.getErrorOnELNotFound().equals(value)) {
+                        err.jspError(n, "jsp.error.tag.conflict.errorOnELNotFound", pageInfo.getErrorOnELNotFound(), value);
                     }
                 }
             }

--- a/src/main/java/org/glassfish/wasp/compiler/Validator.java
+++ b/src/main/java/org/glassfish/wasp/compiler/Validator.java
@@ -17,6 +17,9 @@
 
 package org.glassfish.wasp.compiler;
 
+import static org.glassfish.wasp.compiler.JspUtil.checkAttributes;
+import static org.glassfish.wasp.compiler.JspUtil.checkScope;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -24,8 +27,8 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 
-import org.glassfish.wasp.WaspException;
 import org.glassfish.wasp.JspCompilationContext;
+import org.glassfish.wasp.WaspException;
 import org.glassfish.wasp.runtime.JspRuntimeLibrary;
 import org.xml.sax.Attributes;
 
@@ -58,12 +61,22 @@ class Validator {
         private PageInfo pageInfo;
         private ErrorDispatcher err;
 
-        private static final JspUtil.ValidAttribute[] pageDirectiveAttrs = { new JspUtil.ValidAttribute("language"), new JspUtil.ValidAttribute("extends"),
-                new JspUtil.ValidAttribute("import"), new JspUtil.ValidAttribute("session"), new JspUtil.ValidAttribute("buffer"),
-                new JspUtil.ValidAttribute("autoFlush"), new JspUtil.ValidAttribute("isThreadSafe"), new JspUtil.ValidAttribute("info"),
-                new JspUtil.ValidAttribute("errorPage"), new JspUtil.ValidAttribute("isErrorPage"), new JspUtil.ValidAttribute("contentType"),
-                new JspUtil.ValidAttribute("pageEncoding"), new JspUtil.ValidAttribute("isELIgnored"),
-                new JspUtil.ValidAttribute("deferredSyntaxAllowedAsLiteral"), new JspUtil.ValidAttribute("trimDirectiveWhitespaces") };
+        private static final JspUtil.ValidAttribute[] pageDirectiveAttrs = {
+                new JspUtil.ValidAttribute("language"),
+                new JspUtil.ValidAttribute("extends"),
+                new JspUtil.ValidAttribute("import"),
+                new JspUtil.ValidAttribute("session"),
+                new JspUtil.ValidAttribute("buffer"),
+                new JspUtil.ValidAttribute("autoFlush"),
+                new JspUtil.ValidAttribute("isThreadSafe"),
+                new JspUtil.ValidAttribute("info"),
+                new JspUtil.ValidAttribute("errorPage"),
+                new JspUtil.ValidAttribute("isErrorPage"),
+                new JspUtil.ValidAttribute("contentType"),
+                new JspUtil.ValidAttribute("pageEncoding"),
+                new JspUtil.ValidAttribute("isELIgnored"),
+                new JspUtil.ValidAttribute("deferredSyntaxAllowedAsLiteral"),
+                new JspUtil.ValidAttribute("trimDirectiveWhitespaces") };
 
         private boolean pageEncodingSeen = false;
 
@@ -87,8 +100,7 @@ class Validator {
 
         @Override
         public void visit(Node.PageDirective n) throws WaspException {
-
-            JspUtil.checkAttributes("Page directive", n, pageDirectiveAttrs, err);
+            checkAttributes("Page directive", n, pageDirectiveAttrs, err);
 
             // JSP.2.10.1
             Attributes attrs = n.getAttributes();
@@ -347,47 +359,81 @@ class Validator {
         private ClassLoader loader;
         private JspCompilationContext ctxt;
 
-        private static final JspUtil.ValidAttribute[] jspRootAttrs = { new JspUtil.ValidAttribute("xsi:schemaLocation"),
+        private static final JspUtil.ValidAttribute[] jspRootAttrs = {
+                new JspUtil.ValidAttribute("xsi:schemaLocation"),
                 new JspUtil.ValidAttribute("version", true) };
 
-        private static final JspUtil.ValidAttribute[] includeDirectiveAttrs = { new JspUtil.ValidAttribute("file", true) };
+        private static final JspUtil.ValidAttribute[] includeDirectiveAttrs = {
+                new JspUtil.ValidAttribute("file", true) };
 
-        private static final JspUtil.ValidAttribute[] taglibDirectiveAttrs = { new JspUtil.ValidAttribute("uri"), new JspUtil.ValidAttribute("tagdir"),
+        private static final JspUtil.ValidAttribute[] taglibDirectiveAttrs = {
+                new JspUtil.ValidAttribute("uri"),
+                new JspUtil.ValidAttribute("tagdir"),
                 new JspUtil.ValidAttribute("prefix", true) };
 
-        private static final JspUtil.ValidAttribute[] includeActionAttrs = { new JspUtil.ValidAttribute("page", true), new JspUtil.ValidAttribute("flush") };
+        private static final JspUtil.ValidAttribute[] includeActionAttrs = {
+                new JspUtil.ValidAttribute("page", true),
+                new JspUtil.ValidAttribute("flush") };
 
-        private static final JspUtil.ValidAttribute[] paramActionAttrs = { new JspUtil.ValidAttribute("name", true),
+        private static final JspUtil.ValidAttribute[] paramActionAttrs = {
+                new JspUtil.ValidAttribute("name", true),
                 new JspUtil.ValidAttribute("value", true) };
 
-        private static final JspUtil.ValidAttribute[] forwardActionAttrs = { new JspUtil.ValidAttribute("page", true) };
+        private static final JspUtil.ValidAttribute[] forwardActionAttrs = {
+                new JspUtil.ValidAttribute("page", true) };
 
-        private static final JspUtil.ValidAttribute[] getPropertyAttrs = { new JspUtil.ValidAttribute("name", true),
+        private static final JspUtil.ValidAttribute[] getPropertyAttrs = {
+                new JspUtil.ValidAttribute("name", true),
                 new JspUtil.ValidAttribute("property", true) };
 
-        private static final JspUtil.ValidAttribute[] setPropertyAttrs = { new JspUtil.ValidAttribute("name", true),
-                new JspUtil.ValidAttribute("property", true), new JspUtil.ValidAttribute("value", false), new JspUtil.ValidAttribute("param") };
+        private static final JspUtil.ValidAttribute[] setPropertyAttrs = {
+                new JspUtil.ValidAttribute("name", true),
+                new JspUtil.ValidAttribute("property", true),
+                new JspUtil.ValidAttribute("value", false),
+                new JspUtil.ValidAttribute("param") };
 
-        private static final JspUtil.ValidAttribute[] useBeanAttrs = { new JspUtil.ValidAttribute("id", true), new JspUtil.ValidAttribute("scope"),
-                new JspUtil.ValidAttribute("class"), new JspUtil.ValidAttribute("type"), new JspUtil.ValidAttribute("beanName", false) };
+        private static final JspUtil.ValidAttribute[] useBeanAttrs = {
+                new JspUtil.ValidAttribute("id", true),
+                new JspUtil.ValidAttribute("scope"),
+                new JspUtil.ValidAttribute("class"),
+                new JspUtil.ValidAttribute("type"),
+                new JspUtil.ValidAttribute("beanName", false) };
 
-        private static final JspUtil.ValidAttribute[] plugInAttrs = { new JspUtil.ValidAttribute("type", true), new JspUtil.ValidAttribute("code", true),
-                new JspUtil.ValidAttribute("codebase"), new JspUtil.ValidAttribute("align"), new JspUtil.ValidAttribute("archive"),
-                new JspUtil.ValidAttribute("height", false), new JspUtil.ValidAttribute("hspace"), new JspUtil.ValidAttribute("jreversion"),
-                new JspUtil.ValidAttribute("name"), new JspUtil.ValidAttribute("vspace"), new JspUtil.ValidAttribute("width", false),
-                new JspUtil.ValidAttribute("nspluginurl"), new JspUtil.ValidAttribute("iepluginurl") };
+        private static final JspUtil.ValidAttribute[] plugInAttrs = {
+                new JspUtil.ValidAttribute("type", true),
+                new JspUtil.ValidAttribute("code", true),
+                new JspUtil.ValidAttribute("codebase"),
+                new JspUtil.ValidAttribute("align"),
+                new JspUtil.ValidAttribute("archive"),
+                new JspUtil.ValidAttribute("height", false),
+                new JspUtil.ValidAttribute("hspace"),
+                new JspUtil.ValidAttribute("jreversion"),
+                new JspUtil.ValidAttribute("name"),
+                new JspUtil.ValidAttribute("vspace"),
+                new JspUtil.ValidAttribute("width", false),
+                new JspUtil.ValidAttribute("nspluginurl"),
+                new JspUtil.ValidAttribute("iepluginurl") };
 
-        private static final JspUtil.ValidAttribute[] attributeAttrs = { new JspUtil.ValidAttribute("name", true), new JspUtil.ValidAttribute("trim"),
+        private static final JspUtil.ValidAttribute[] attributeAttrs = {
+                new JspUtil.ValidAttribute("name", true),
+                new JspUtil.ValidAttribute("trim"),
                 new JspUtil.ValidAttribute("omit") };
 
-        private static final JspUtil.ValidAttribute[] invokeAttrs = { new JspUtil.ValidAttribute("fragment", true), new JspUtil.ValidAttribute("var"),
-                new JspUtil.ValidAttribute("varReader"), new JspUtil.ValidAttribute("scope") };
-
-        private static final JspUtil.ValidAttribute[] doBodyAttrs = { new JspUtil.ValidAttribute("var"), new JspUtil.ValidAttribute("varReader"),
+        private static final JspUtil.ValidAttribute[] invokeAttrs = {
+                new JspUtil.ValidAttribute("fragment", true),
+                new JspUtil.ValidAttribute("var"),
+                new JspUtil.ValidAttribute("varReader"),
                 new JspUtil.ValidAttribute("scope") };
 
-        private static final JspUtil.ValidAttribute[] jspOutputAttrs = { new JspUtil.ValidAttribute("omit-xml-declaration"),
-                new JspUtil.ValidAttribute("doctype-root-element"), new JspUtil.ValidAttribute("doctype-public"),
+        private static final JspUtil.ValidAttribute[] doBodyAttrs = {
+                new JspUtil.ValidAttribute("var"),
+                new JspUtil.ValidAttribute("varReader"),
+                new JspUtil.ValidAttribute("scope") };
+
+        private static final JspUtil.ValidAttribute[] jspOutputAttrs = {
+                new JspUtil.ValidAttribute("omit-xml-declaration"),
+                new JspUtil.ValidAttribute("doctype-root-element"),
+                new JspUtil.ValidAttribute("doctype-public"),
                 new JspUtil.ValidAttribute("doctype-system") };
 
         /*
@@ -402,7 +448,7 @@ class Validator {
 
         @Override
         public void visit(Node.JspRoot n) throws WaspException {
-            JspUtil.checkAttributes("Jsp:root", n, jspRootAttrs, err);
+            checkAttributes("Jsp:root", n, jspRootAttrs, err);
             String version = n.getTextAttribute("version");
             if (!version.equals("1.2") && !version.equals("2.0") && !version.equals("2.1")) {
                 err.jspError(n, "jsp.error.jsproot.version.invalid", version);
@@ -412,13 +458,14 @@ class Validator {
 
         @Override
         public void visit(Node.IncludeDirective n) throws WaspException {
-            JspUtil.checkAttributes("Include directive", n, includeDirectiveAttrs, err);
+            checkAttributes("Include directive", n, includeDirectiveAttrs, err);
             visitBody(n);
         }
 
         @Override
         public void visit(Node.TaglibDirective n) throws WaspException {
-            JspUtil.checkAttributes("Taglib directive", n, taglibDirectiveAttrs, err);
+            checkAttributes("Taglib directive", n, taglibDirectiveAttrs, err);
+
             // Either 'uri' or 'tagdir' attribute must be specified
             String uri = n.getAttributeValue("uri");
             String tagdir = n.getAttributeValue("tagdir");
@@ -432,7 +479,8 @@ class Validator {
 
         @Override
         public void visit(Node.ParamAction n) throws WaspException {
-            JspUtil.checkAttributes("Param action", n, paramActionAttrs, err);
+            checkAttributes("Param action", n, paramActionAttrs, err);
+
             // make sure the value of the 'name' attribute is not a
             // request-time expression
             throwErrorIfExpression(n, "name", "jsp:param");
@@ -452,26 +500,26 @@ class Validator {
 
         @Override
         public void visit(Node.IncludeAction n) throws WaspException {
-            JspUtil.checkAttributes("Include action", n, includeActionAttrs, err);
+            checkAttributes("Include action", n, includeActionAttrs, err);
             n.setPage(getJspAttribute("page", null, null, n.getAttributeValue("page"), n, false, null));
             visitBody(n);
         }
 
         @Override
         public void visit(Node.ForwardAction n) throws WaspException {
-            JspUtil.checkAttributes("Forward", n, forwardActionAttrs, err);
+            checkAttributes("Forward", n, forwardActionAttrs, err);
             n.setPage(getJspAttribute("page", null, null, n.getAttributeValue("page"), n, false, null));
             visitBody(n);
         }
 
         @Override
         public void visit(Node.GetProperty n) throws WaspException {
-            JspUtil.checkAttributes("GetProperty", n, getPropertyAttrs, err);
+            checkAttributes("GetProperty", n, getPropertyAttrs, err);
         }
 
         @Override
         public void visit(Node.SetProperty n) throws WaspException {
-            JspUtil.checkAttributes("SetProperty", n, setPropertyAttrs, err);
+            checkAttributes("SetProperty", n, setPropertyAttrs, err);
             String property = n.getTextAttribute("property");
             String param = n.getTextAttribute("param");
             String value = n.getAttributeValue("value");
@@ -493,121 +541,122 @@ class Validator {
         }
 
         @Override
-        public void visit(Node.UseBean n) throws WaspException {
-            JspUtil.checkAttributes("UseBean", n, useBeanAttrs, err);
+        public void visit(Node.UseBean useBean) throws WaspException {
+            checkAttributes("UseBean", useBean, useBeanAttrs, err);
 
-            String name = n.getTextAttribute("id");
-            String scope = n.getTextAttribute("scope");
-            JspUtil.checkScope(scope, n, err);
-            String className = n.getTextAttribute("class");
-            String type = n.getTextAttribute("type");
+            String name = useBean.getTextAttribute("id");
+            String scope = useBean.getTextAttribute("scope");
+            checkScope(scope, useBean, err);
+            String className = useBean.getTextAttribute("class");
+            String type = useBean.getTextAttribute("type");
             BeanRepository beanInfo = pageInfo.getBeanRepository();
 
             if (className == null && type == null) {
-                err.jspError(n, "jsp.error.usebean.missingType");
+                err.jspError(useBean, "jsp.error.usebean.missingType");
             }
 
             if (beanInfo.checkVariable(name)) {
-                err.jspError(n, "jsp.error.usebean.duplicate", name);
+                err.jspError(useBean, "jsp.error.usebean.duplicate", name);
             }
 
             if ("session".equals(scope) && !pageInfo.isSession()) {
-                err.jspError(n, "jsp.error.usebean.noSession");
+                err.jspError(useBean, "jsp.error.usebean.noSession");
             }
 
-            Node.JspAttribute jattr = getJspAttribute("beanName", null, null, n.getAttributeValue("beanName"), n, false, null);
-            n.setBeanName(jattr);
+            Node.JspAttribute jattr = getJspAttribute("beanName", null, null, useBean.getAttributeValue("beanName"), useBean, false, null);
+            useBean.setBeanName(jattr);
             if (className != null && jattr != null) {
-                err.jspError(n, "jsp.error.usebean.notBoth");
+                err.jspError(useBean, "jsp.error.usebean.notBoth");
             }
 
             if (className == null) {
                 className = type;
             }
 
-            beanInfo.addBean(n, name, className, scope);
+            beanInfo.addBean(useBean, name, className, scope);
 
-            visitBody(n);
+            visitBody(useBean);
         }
 
         @Override
-        public void visit(Node.PlugIn n) throws WaspException {
-            JspUtil.checkAttributes("Plugin", n, plugInAttrs, err);
+        public void visit(Node.PlugIn plugIn) throws WaspException {
+            checkAttributes("Plugin", plugIn, plugInAttrs, err);
 
-            throwErrorIfExpression(n, "type", "jsp:plugin");
-            throwErrorIfExpression(n, "code", "jsp:plugin");
-            throwErrorIfExpression(n, "codebase", "jsp:plugin");
-            throwErrorIfExpression(n, "align", "jsp:plugin");
-            throwErrorIfExpression(n, "archive", "jsp:plugin");
-            throwErrorIfExpression(n, "hspace", "jsp:plugin");
-            throwErrorIfExpression(n, "jreversion", "jsp:plugin");
-            throwErrorIfExpression(n, "name", "jsp:plugin");
-            throwErrorIfExpression(n, "vspace", "jsp:plugin");
-            throwErrorIfExpression(n, "nspluginurl", "jsp:plugin");
-            throwErrorIfExpression(n, "iepluginurl", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "type", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "code", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "codebase", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "align", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "archive", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "hspace", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "jreversion", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "name", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "vspace", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "nspluginurl", "jsp:plugin");
+            throwErrorIfExpression(plugIn, "iepluginurl", "jsp:plugin");
 
-            String type = n.getTextAttribute("type");
+            String type = plugIn.getTextAttribute("type");
             if (type == null) {
-                err.jspError(n, "jsp.error.plugin.notype");
+                err.jspError(plugIn, "jsp.error.plugin.notype");
             }
             if (!type.equals("bean") && !type.equals("applet")) {
-                err.jspError(n, "jsp.error.plugin.badtype");
+                err.jspError(plugIn, "jsp.error.plugin.badtype");
             }
-            if (n.getTextAttribute("code") == null) {
-                err.jspError(n, "jsp.error.plugin.nocode");
+            if (plugIn.getTextAttribute("code") == null) {
+                err.jspError(plugIn, "jsp.error.plugin.nocode");
             }
 
-            Node.JspAttribute width = getJspAttribute("width", null, null, n.getAttributeValue("width"), n, false, null);
-            n.setWidth(width);
+            Node.JspAttribute width = getJspAttribute("width", null, null, plugIn.getAttributeValue("width"), plugIn, false, null);
+            plugIn.setWidth(width);
 
-            Node.JspAttribute height = getJspAttribute("height", null, null, n.getAttributeValue("height"), n, false, null);
-            n.setHeight(height);
+            Node.JspAttribute height = getJspAttribute("height", null, null, plugIn.getAttributeValue("height"), plugIn, false, null);
+            plugIn.setHeight(height);
 
-            visitBody(n);
+            visitBody(plugIn);
         }
 
         @Override
-        public void visit(Node.NamedAttribute n) throws WaspException {
-            JspUtil.checkAttributes("Attribute", n, attributeAttrs, err);
-            String omit = n.getAttributeValue("omit");
+        public void visit(Node.NamedAttribute namedAttribute) throws WaspException {
+            checkAttributes("Attribute", namedAttribute, attributeAttrs, err);
+            String omit = namedAttribute.getAttributeValue("omit");
             if (omit != null) {
-                n.setOmit(getJspAttribute("omit", null, null, omit, n, false, null));
+                namedAttribute.setOmit(getJspAttribute("omit", null, null, omit, namedAttribute, false, null));
             }
-            visitBody(n);
+            visitBody(namedAttribute);
         }
 
         @Override
-        public void visit(Node.JspBody n) throws WaspException {
-            visitBody(n);
+        public void visit(Node.JspBody pagesBody) throws WaspException {
+            visitBody(pagesBody);
         }
 
         @Override
-        public void visit(Node.Declaration n) throws WaspException {
+        public void visit(Node.Declaration declaration) throws WaspException {
             if (pageInfo.isScriptingInvalid()) {
-                err.jspError(n.getStart(), "jsp.error.no.scriptlets");
+                err.jspError(declaration.getStart(), "jsp.error.no.scriptlets");
             }
         }
 
         @Override
-        public void visit(Node.Expression n) throws WaspException {
+        public void visit(Node.Expression expression) throws WaspException {
             if (pageInfo.isScriptingInvalid()) {
-                err.jspError(n.getStart(), "jsp.error.no.scriptlets");
+                err.jspError(expression.getStart(), "jsp.error.no.scriptlets");
             }
         }
 
         @Override
-        public void visit(Node.Scriptlet n) throws WaspException {
+        public void visit(Node.Scriptlet scriptlet) throws WaspException {
             if (pageInfo.isScriptingInvalid()) {
-                err.jspError(n.getStart(), "jsp.error.no.scriptlets");
+                err.jspError(scriptlet.getStart(), "jsp.error.no.scriptlets");
             }
         }
 
         @Override
-        public void visit(Node.ELExpression n) throws WaspException {
+        public void visit(Node.ELExpression expression) throws WaspException {
             if (pageInfo.isELIgnored()) {
                 return;
             }
-            String expressions = n.getText();
+
+            String expressions = expression.getText();
             if (expressions.charAt(0) == '#') {
                 if (pageInfo.isDeferredSyntaxAllowedAsLiteral()) {
                     return;
@@ -622,54 +671,58 @@ class Validator {
                     }
                 }
 
-                err.jspError(n.getStart(), "jsp.error.not.in.template", "#{...}");
+                err.jspError(expression.getStart(), "jsp.error.not.in.template", "#{...}");
             }
             ELNode.Nodes el = ELParser.parse(expressions);
-            validateFunctions(el, n);
-            JspUtil.validateExpressions(n.getStart(), expressions, getFunctionMapper(el), err);
-            n.setEL(el);
+            validateFunctions(el, expression);
+            JspUtil.validateExpressions(expression.getStart(), expressions, getFunctionMapper(el), err);
+            expression.setEL(el);
         }
 
         @Override
-        public void visit(Node.UninterpretedTag n) throws WaspException {
-            if (n.getNamedAttributeNodes().size() != 0) {
-                err.jspError(n, "jsp.error.namedAttribute.invalidUse");
+        public void visit(Node.UninterpretedTag uninterpretedTag) throws WaspException {
+            if (uninterpretedTag.getNamedAttributeNodes().size() != 0) {
+                err.jspError(uninterpretedTag, "jsp.error.namedAttribute.invalidUse");
             }
 
-            Attributes attrs = n.getAttributes();
+            Attributes attrs = uninterpretedTag.getAttributes();
             if (attrs != null) {
                 int attrSize = attrs.getLength();
                 Node.JspAttribute[] jspAttrs = new Node.JspAttribute[attrSize];
                 for (int i = 0; i < attrSize; i++) {
-                    jspAttrs[i] = getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), n, false, null);
+                    jspAttrs[i] = getJspAttribute(
+                                    attrs.getQName(i),
+                                    attrs.getURI(i),
+                                    attrs.getLocalName(i),
+                                    attrs.getValue(i),
+                                    uninterpretedTag, false, null);
                 }
-                n.setJspAttributes(jspAttrs);
+                uninterpretedTag.setJspAttributes(jspAttrs);
             }
 
-            visitBody(n);
+            visitBody(uninterpretedTag);
         }
 
         @Override
-        public void visit(Node.CustomTag n) throws WaspException {
-
-            TagInfo tagInfo = n.getTagInfo();
+        public void visit(Node.CustomTag customTag) throws WaspException {
+            TagInfo tagInfo = customTag.getTagInfo();
             if (tagInfo == null) {
-                err.jspError(n, "jsp.error.missing.tagInfo", n.getQName());
+                err.jspError(customTag, "jsp.error.missing.tagInfo", customTag.getQName());
             }
 
             /*
              * The bodycontent of a SimpleTag cannot be JSP.
              */
-            if (n.implementsSimpleTag() && tagInfo.getBodyContent().equals(TagInfo.BODY_CONTENT_JSP)) {
-                err.jspError(n, "jsp.error.simpletag.badbodycontent", tagInfo.getTagClassName());
+            if (customTag.implementsSimpleTag() && tagInfo.getBodyContent().equals(TagInfo.BODY_CONTENT_JSP)) {
+                err.jspError(customTag, "jsp.error.simpletag.badbodycontent", tagInfo.getTagClassName());
             }
 
             /*
              * If the tag handler declares in the TLD that it supports dynamic attributes, it also must implement the
              * DynamicAttributes interface.
              */
-            if (tagInfo.hasDynamicAttributes() && !n.implementsDynamicAttributes()) {
-                err.jspError(n, "jsp.error.dynamic.attributes.not.implemented", n.getQName());
+            if (tagInfo.hasDynamicAttributes() && !customTag.implementsDynamicAttributes()) {
+                err.jspError(customTag, "jsp.error.dynamic.attributes.not.implemented", customTag.getQName());
             }
 
             /*
@@ -677,8 +730,8 @@ class Validator {
              * sure that the same attribute is not specified in both attributes or named attributes.
              */
             TagAttributeInfo[] tldAttrs = tagInfo.getAttributes();
-            String customActionUri = n.getURI();
-            Attributes attrs = n.getAttributes();
+            String customActionUri = customTag.getURI();
+            Attributes attrs = customTag.getAttributes();
             int attrsSize = attrs == null ? 0 : attrs.getLength();
             for (int i = 0; i < tldAttrs.length; i++) {
                 String attr = null;
@@ -688,17 +741,17 @@ class Validator {
                         attr = attrs.getValue(customActionUri, tldAttrs[i].getName());
                     }
                 }
-                Node.NamedAttribute na = n.getNamedAttributeNode(tldAttrs[i].getName());
+                Node.NamedAttribute na = customTag.getNamedAttributeNode(tldAttrs[i].getName());
 
                 if (tldAttrs[i].isRequired() && attr == null && na == null) {
-                    err.jspError(n, "jsp.error.missing_attribute", tldAttrs[i].getName(), n.getLocalName());
+                    err.jspError(customTag, "jsp.error.missing_attribute", tldAttrs[i].getName(), customTag.getLocalName());
                 }
                 if (attr != null && na != null) {
-                    err.jspError(n, "jsp.error.duplicate.name.jspattribute", tldAttrs[i].getName());
+                    err.jspError(customTag, "jsp.error.duplicate.name.jspattribute", tldAttrs[i].getName());
                 }
             }
 
-            Node.Nodes naNodes = n.getNamedAttributeNodes();
+            Node.Nodes naNodes = customTag.getNamedAttributeNodes();
             int jspAttrsSize = naNodes.size() + attrsSize;
             Node.JspAttribute[] jspAttrs = null;
             if (jspAttrsSize > 0) {
@@ -706,8 +759,8 @@ class Validator {
             }
             Hashtable<String, Object> tagDataAttrs = new Hashtable<>(attrsSize);
 
-            checkXmlAttributes(n, jspAttrs, tagDataAttrs);
-            checkNamedAttributes(n, jspAttrs, attrsSize, tagDataAttrs);
+            checkXmlAttributes(customTag, jspAttrs, tagDataAttrs);
+            checkNamedAttributes(customTag, jspAttrs, attrsSize, tagDataAttrs);
 
             TagData tagData = new TagData(tagDataAttrs);
 
@@ -716,25 +769,24 @@ class Validator {
             // class that returns a non-null object.
             TagExtraInfo tei = tagInfo.getTagExtraInfo();
             if (tei != null && tei.getVariableInfo(tagData) != null && tei.getVariableInfo(tagData).length > 0 && tagInfo.getTagVariableInfos().length > 0) {
-                err.jspError("jsp.error.non_null_tei_and_var_subelems", n.getQName());
+                err.jspError("jsp.error.non_null_tei_and_var_subelems", customTag.getQName());
             }
 
-            n.setTagData(tagData);
-            n.setJspAttributes(jspAttrs);
+            customTag.setTagData(tagData);
+            customTag.setJspAttributes(jspAttrs);
 
-            visitBody(n);
+            visitBody(customTag);
         }
 
         @Override
-        public void visit(Node.JspElement n) throws WaspException {
-
-            Attributes attrs = n.getAttributes();
+        public void visit(Node.JspElement pagesElement) throws WaspException {
+            Attributes attrs = pagesElement.getAttributes();
             if (attrs == null) {
-                err.jspError(n, "jsp.error.jspelement.missing.name");
+                err.jspError(pagesElement, "jsp.error.jspelement.missing.name");
             }
             int xmlAttrLen = attrs.getLength();
 
-            Node.Nodes namedAttrs = n.getNamedAttributeNodes();
+            Node.Nodes namedAttrs = pagesElement.getNamedAttributeNodes();
 
             // XML-style 'name' attribute, which is mandatory, must not be
             // included in JspAttribute array
@@ -746,16 +798,16 @@ class Validator {
             // Process XML-style attributes
             for (int i = 0; i < xmlAttrLen; i++) {
                 if ("name".equals(attrs.getLocalName(i))) {
-                    n.setNameAttribute(getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), n, false, null));
+                    pagesElement.setNameAttribute(getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), pagesElement, false, null));
                 } else {
                     if (jspAttrIndex < jspAttrSize) {
-                        jspAttrs[jspAttrIndex++] = getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), n, false,
+                        jspAttrs[jspAttrIndex++] = getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), pagesElement, false,
                                 null);
                     }
                 }
             }
-            if (n.getNameAttribute() == null) {
-                err.jspError(n, "jsp.error.jspelement.missing.name");
+            if (pagesElement.getNameAttribute() == null) {
+                err.jspError(pagesElement, "jsp.error.jspelement.missing.name");
             }
 
             // Process named attributes
@@ -764,23 +816,23 @@ class Validator {
                 jspAttrs[jspAttrIndex++] = new Node.JspAttribute(na, false);
             }
 
-            n.setJspAttributes(jspAttrs);
+            pagesElement.setJspAttributes(jspAttrs);
 
-            visitBody(n);
+            visitBody(pagesElement);
         }
 
         @Override
-        public void visit(Node.JspOutput n) throws WaspException {
-            JspUtil.checkAttributes("jsp:output", n, jspOutputAttrs, err);
+        public void visit(Node.JspOutput pagesOutput) throws WaspException {
+            checkAttributes("jsp:output", pagesOutput, jspOutputAttrs, err);
 
-            if (n.getBody() != null) {
-                err.jspError(n, "jsp.error.jspoutput.nonemptybody");
+            if (pagesOutput.getBody() != null) {
+                err.jspError(pagesOutput, "jsp.error.jspoutput.nonemptybody");
             }
 
-            String omitXmlDecl = n.getAttributeValue("omit-xml-declaration");
-            String doctypeName = n.getAttributeValue("doctype-root-element");
-            String doctypePublic = n.getAttributeValue("doctype-public");
-            String doctypeSystem = n.getAttributeValue("doctype-system");
+            String omitXmlDecl = pagesOutput.getAttributeValue("omit-xml-declaration");
+            String doctypeName = pagesOutput.getAttributeValue("doctype-root-element");
+            String doctypePublic = pagesOutput.getAttributeValue("doctype-public");
+            String doctypeSystem = pagesOutput.getAttributeValue("doctype-system");
 
             String omitXmlDeclOld = pageInfo.getOmitXmlDecl();
             String doctypeNameOld = pageInfo.getDoctypeName();
@@ -788,27 +840,27 @@ class Validator {
             String doctypeSystemOld = pageInfo.getDoctypeSystem();
 
             if (omitXmlDecl != null && omitXmlDeclOld != null && !omitXmlDecl.equals(omitXmlDeclOld)) {
-                err.jspError(n, "jsp.error.jspoutput.conflict", "omit-xml-declaration", omitXmlDeclOld, omitXmlDecl);
+                err.jspError(pagesOutput, "jsp.error.jspoutput.conflict", "omit-xml-declaration", omitXmlDeclOld, omitXmlDecl);
             }
 
             if (doctypeName != null && doctypeNameOld != null && !doctypeName.equals(doctypeNameOld)) {
-                err.jspError(n, "jsp.error.jspoutput.conflict", "doctype-root-element", doctypeNameOld, doctypeName);
+                err.jspError(pagesOutput, "jsp.error.jspoutput.conflict", "doctype-root-element", doctypeNameOld, doctypeName);
             }
 
             if (doctypePublic != null && doctypePublicOld != null && !doctypePublic.equals(doctypePublicOld)) {
-                err.jspError(n, "jsp.error.jspoutput.conflict", "doctype-public", doctypePublicOld, doctypePublic);
+                err.jspError(pagesOutput, "jsp.error.jspoutput.conflict", "doctype-public", doctypePublicOld, doctypePublic);
             }
 
             if (doctypeSystem != null && doctypeSystemOld != null && !doctypeSystem.equals(doctypeSystemOld)) {
-                err.jspError(n, "jsp.error.jspoutput.conflict", "doctype-system", doctypeSystemOld, doctypeSystem);
+                err.jspError(pagesOutput, "jsp.error.jspoutput.conflict", "doctype-system", doctypeSystemOld, doctypeSystem);
             }
 
             if (doctypeName == null && doctypeSystem != null || doctypeName != null && doctypeSystem == null) {
-                err.jspError(n, "jsp.error.jspoutput.doctypenamesystem");
+                err.jspError(pagesOutput, "jsp.error.jspoutput.doctypenamesystem");
             }
 
             if (doctypePublic != null && doctypeSystem == null) {
-                err.jspError(n, "jsp.error.jspoutput.doctypepulicsystem");
+                err.jspError(pagesOutput, "jsp.error.jspoutput.doctypepulicsystem");
             }
 
             if (omitXmlDecl != null) {
@@ -826,38 +878,36 @@ class Validator {
         }
 
         @Override
-        public void visit(Node.InvokeAction n) throws WaspException {
+        public void visit(Node.InvokeAction invokeAction) throws WaspException {
+            checkAttributes("Invoke", invokeAction, invokeAttrs, err);
 
-            JspUtil.checkAttributes("Invoke", n, invokeAttrs, err);
+            String scope = invokeAction.getTextAttribute("scope");
+            checkScope(scope, invokeAction, err);
 
-            String scope = n.getTextAttribute("scope");
-            JspUtil.checkScope(scope, n, err);
-
-            String var = n.getTextAttribute("var");
-            String varReader = n.getTextAttribute("varReader");
+            String var = invokeAction.getTextAttribute("var");
+            String varReader = invokeAction.getTextAttribute("varReader");
             if (scope != null && var == null && varReader == null) {
-                err.jspError(n, "jsp.error.missing_var_or_varReader");
+                err.jspError(invokeAction, "jsp.error.missing_var_or_varReader");
             }
             if (var != null && varReader != null) {
-                err.jspError(n, "jsp.error.var_and_varReader");
+                err.jspError(invokeAction, "jsp.error.var_and_varReader");
             }
         }
 
         @Override
-        public void visit(Node.DoBodyAction n) throws WaspException {
+        public void visit(Node.DoBodyAction doBodyAction) throws WaspException {
+            checkAttributes("DoBody", doBodyAction, doBodyAttrs, err);
 
-            JspUtil.checkAttributes("DoBody", n, doBodyAttrs, err);
+            String scope = doBodyAction.getTextAttribute("scope");
+            checkScope(scope, doBodyAction, err);
 
-            String scope = n.getTextAttribute("scope");
-            JspUtil.checkScope(scope, n, err);
-
-            String var = n.getTextAttribute("var");
-            String varReader = n.getTextAttribute("varReader");
+            String var = doBodyAction.getTextAttribute("var");
+            String varReader = doBodyAction.getTextAttribute("varReader");
             if (scope != null && var == null && varReader == null) {
-                err.jspError(n, "jsp.error.missing_var_or_varReader");
+                err.jspError(doBodyAction, "jsp.error.missing_var_or_varReader");
             }
             if (var != null && varReader != null) {
-                err.jspError(n, "jsp.error.var_and_varReader");
+                err.jspError(doBodyAction, "jsp.error.var_and_varReader");
             }
         }
 
@@ -867,9 +917,8 @@ class Validator {
          * This can probably be done globally, when taglib directives are processed. We do it here so checking is done only for
          * the attributes are actually used.
          */
-        private void checkSetter(Node.CustomTag n, TagAttributeInfo tldattr) throws WaspException {
-
-            Class handler = n.getTagHandlerClass();
+        private void checkSetter(Node.CustomTag customTag, TagAttributeInfo tldattr) throws WaspException {
+            Class<?> handler = customTag.getTagHandlerClass();
             if (handler == null) {
                 // Handler unknown. Maybe tag file?
                 return;
@@ -884,25 +933,26 @@ class Validator {
             } catch (Exception ex) {
             }
             if (setter == null) {
-                err.jspError(n, "jsp.error.setter.none", handlerName, property);
+                err.jspError(customTag, "jsp.error.setter.none", handlerName, property);
             }
-            Class setterType = setter.getParameterTypes()[0];
+
+            Class<?> setterType = setter.getParameterTypes()[0];
             String typeName = setterType.getName();
             if (tldattr.isDeferredValue()) {
                 if (tldattr.canBeRequestTime()) {
                     if (!"java.lang.Object".equals(typeName)) {
-                        err.jspError(n, "jsp.error.setter.notobject", handlerName, property);
+                        err.jspError(customTag, "jsp.error.setter.notobject", handlerName, property);
                     }
                     return;
                 }
                 if (!"jakarta.el.ValueExpression".equals(typeName)) {
-                    err.jspError(n, "jsp.error.setter.notvalueexpression", handlerName, property);
+                    err.jspError(customTag, "jsp.error.setter.notvalueexpression", handlerName, property);
                 }
                 return;
             }
             if (tldattr.isDeferredMethod()) {
                 if (!"jakarta.el.MethodExpression".equals(typeName)) {
-                    err.jspError(n, "jsp.error.setter.notmethodexpression", handlerName, property);
+                    err.jspError(customTag, "jsp.error.setter.notmethodexpression", handlerName, property);
                 }
             }
             /*
@@ -928,36 +978,36 @@ class Validator {
          * An action attribute may have a prefix different from that of the action invocation only if the underlying tag handler
          * supports dynamic attributes, in which case the attribute with the different prefix is considered a dynamic attribute.
          */
-        private void checkXmlAttributes(Node.CustomTag n, Node.JspAttribute[] jspAttrs, Hashtable<String, Object> tagDataAttrs) throws WaspException {
-
-            TagInfo tagInfo = n.getTagInfo();
+        private void checkXmlAttributes(Node.CustomTag customTag, Node.JspAttribute[] jspAttrs, Hashtable<String, Object> tagDataAttrs) throws WaspException {
+            TagInfo tagInfo = customTag.getTagInfo();
             if (tagInfo == null) {
-                err.jspError(n, "jsp.error.missing.tagInfo", n.getQName());
+                err.jspError(customTag, "jsp.error.missing.tagInfo", customTag.getQName());
             }
+
             TagAttributeInfo[] tldAttrs = tagInfo.getAttributes();
-            Attributes attrs = n.getAttributes();
+            Attributes attrs = customTag.getAttributes();
 
             for (int i = 0; attrs != null && i < attrs.getLength(); i++) {
                 boolean found = false;
                 for (int j = 0; tldAttrs != null && j < tldAttrs.length; j++) {
                     if (attrs.getLocalName(i).equals(tldAttrs[j].getName())
-                            && (attrs.getURI(i) == null || attrs.getURI(i).length() == 0 || attrs.getURI(i).equals(n.getURI()))) {
+                            && (attrs.getURI(i) == null || attrs.getURI(i).length() == 0 || attrs.getURI(i).equals(customTag.getURI()))) {
 
-                        checkSetter(n, tldAttrs[j]);
+                        checkSetter(customTag, tldAttrs[j]);
 
                         if (tldAttrs[j].canBeRequestTime() || tldAttrs[j].isDeferredValue() || tldAttrs[j].isDeferredMethod()) {
-                            jspAttrs[i] = getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), n, false, tldAttrs[j]);
+                            jspAttrs[i] = getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), customTag, false, tldAttrs[j]);
                             ELNode.Nodes el = jspAttrs[i].getEL();
                             if (el != null) {
                                 if (el.hasDollarExpression()) {
                                     if (!tldAttrs[j].canBeRequestTime()) {
-                                        err.jspError(n, "jsp.error.el.deferred.dollar", tldAttrs[j].getName());
+                                        err.jspError(customTag, "jsp.error.el.deferred.dollar", tldAttrs[j].getName());
                                     }
                                 } else if (el.hasPoundExpression()) {
                                     boolean isLiteral = pageInfo.isDeferredSyntaxAllowedAsLiteral();
                                     if (!tldAttrs[j].isDeferredValue() && !tldAttrs[j].isDeferredMethod()) {
-                                        if (n.getJspVersion() >= 2.1 && !isLiteral) {
-                                            err.jspError(n, "jsp.error.el.nondeferred.pound", tldAttrs[j].getName());
+                                        if (customTag.getJspVersion() >= 2.1 && !isLiteral) {
+                                            err.jspError(customTag, "jsp.error.el.nondeferred.pound", tldAttrs[j].getName());
                                         } else {
                                             isLiteral = true;
                                         }
@@ -975,9 +1025,9 @@ class Validator {
                         } else {
                             // Attribute does not accept any expressions.
                             // Make sure its value does not contain any.
-                            String litAttr = getLiteral(n, attrs.getValue(i));
+                            String litAttr = getLiteral(customTag, attrs.getValue(i));
                             if (litAttr == null) {
-                                err.jspError(n, "jsp.error.attribute.custom.non_rt_with_expr", tldAttrs[j].getName());
+                                err.jspError(customTag, "jsp.error.attribute.custom.non_rt_with_expr", tldAttrs[j].getName());
                             }
                             jspAttrs[i] = new Node.JspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), litAttr, false, null, false);
                         }
@@ -992,9 +1042,9 @@ class Validator {
                 }
                 if (!found) {
                     if (tagInfo.hasDynamicAttributes()) {
-                        jspAttrs[i] = getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), n, true, null);
+                        jspAttrs[i] = getJspAttribute(attrs.getQName(i), attrs.getURI(i), attrs.getLocalName(i), attrs.getValue(i), customTag, true, null);
                     } else {
-                        err.jspError(n, "jsp.error.bad_attribute", attrs.getQName(i), n.getLocalName());
+                        err.jspError(customTag, "jsp.error.bad_attribute", attrs.getQName(i), customTag.getLocalName());
                     }
                 }
             }
@@ -1003,15 +1053,14 @@ class Validator {
         /*
          * Make sure the given custom action does not have any invalid named attributes
          */
-        private void checkNamedAttributes(Node.CustomTag n, Node.JspAttribute[] jspAttrs, int start, Hashtable<String, Object> tagDataAttrs)
-                throws WaspException {
-
-            TagInfo tagInfo = n.getTagInfo();
+        private void checkNamedAttributes(Node.CustomTag customTag, Node.JspAttribute[] jspAttrs, int start, Hashtable<String, Object> tagDataAttrs) throws WaspException {
+            TagInfo tagInfo = customTag.getTagInfo();
             if (tagInfo == null) {
-                err.jspError(n, "jsp.error.missing.tagInfo", n.getQName());
+                err.jspError(customTag, "jsp.error.missing.tagInfo", customTag.getQName());
             }
+
             TagAttributeInfo[] tldAttrs = tagInfo.getAttributes();
-            Node.Nodes naNodes = n.getNamedAttributeNodes();
+            Node.Nodes naNodes = customTag.getNamedAttributeNodes();
 
             for (int i = 0; i < naNodes.size(); i++) {
                 Node.NamedAttribute na = (Node.NamedAttribute) naNodes.getNode(i);
@@ -1024,7 +1073,7 @@ class Validator {
                      */
                     String attrPrefix = na.getPrefix();
                     if (na.getLocalName().equals(tldAttrs[j].getName())
-                            && (attrPrefix == null || attrPrefix.length() == 0 || attrPrefix.equals(n.getPrefix()))) {
+                            && (attrPrefix == null || attrPrefix.length() == 0 || attrPrefix.equals(customTag.getPrefix()))) {
                         jspAttrs[start + i] = new Node.JspAttribute(na, false);
                         NamedAttributeVisitor nav = null;
                         if (na.getBody() != null) {
@@ -1044,7 +1093,7 @@ class Validator {
                     if (tagInfo.hasDynamicAttributes()) {
                         jspAttrs[start + i] = new Node.JspAttribute(na, true);
                     } else {
-                        err.jspError(n, "jsp.error.bad_attribute", na.getName(), n.getLocalName());
+                        err.jspError(customTag, "jsp.error.bad_attribute", na.getName(), customTag.getLocalName());
                     }
                 }
             }
@@ -1142,18 +1191,18 @@ class Validator {
          *
          * @return null, if the attribute is an expression otherwise, the literal string for the attribute
          */
-        private String getLiteral(Node n, String value) {
-            if (n.getRoot().isXmlSyntax() && value.startsWith("%=")) {
+        private String getLiteral(Node node, String value) {
+            if (node.getRoot().isXmlSyntax() && value.startsWith("%=")) {
                 return null;
             }
-            if (!n.getRoot().isXmlSyntax() && value.startsWith("<%=")) {
+            if (!node.getRoot().isXmlSyntax() && value.startsWith("<%=")) {
                 return null;
             }
             if (pageInfo.isELIgnored()) {
                 return value;
             }
-            boolean poundExpressionIgnored = n instanceof Node.CustomTag
-                    && (((Node.CustomTag) n).getJspVersion() < 2.1 || pageInfo.isDeferredSyntaxAllowedAsLiteral());
+            boolean poundExpressionIgnored = node instanceof Node.CustomTag
+                    && (((Node.CustomTag) node).getJspVersion() < 2.1 || pageInfo.isDeferredSyntaxAllowedAsLiteral());
             int size = value.length();
             StringBuilder buf = new StringBuilder(size);
             char p = ' ';
@@ -1189,9 +1238,9 @@ class Validator {
          * Throws exception if the value of the attribute with the given name in the given node is given as an RT or EL
          * expression, but the spec requires a static value.
          */
-        private void throwErrorIfExpression(Node n, String attrName, String actionName) throws WaspException {
-            if (n.getAttributes() != null && n.getAttributes().getValue(attrName) != null && getLiteral(n, n.getAttributes().getValue(attrName)) == null) {
-                err.jspError(n, "jsp.error.attribute.standard.non_rt_with_expr", attrName, actionName);
+        private void throwErrorIfExpression(Node node, String attrName, String actionName) throws WaspException {
+            if (node.getAttributes() != null && node.getAttributes().getValue(attrName) != null && getLiteral(node, node.getAttributes().getValue(attrName)) == null) {
+                err.jspError(node, "jsp.error.attribute.standard.non_rt_with_expr", attrName, actionName);
             }
         }
 
@@ -1232,10 +1281,10 @@ class Validator {
             }
         }
 
-        private String findUri(String prefix, Node n) {
+        private String findUri(String prefix, Node node) {
 
-            for (Node p = n; p != null; p = p.getParent()) {
-                Attributes attrs = p.getTaglibAttributes();
+            for (Node parentNode = node; parentNode != null; parentNode = parentNode.getParent()) {
+                Attributes attrs = parentNode.getTaglibAttributes();
                 if (attrs == null) {
                     continue;
                 }
@@ -1308,22 +1357,22 @@ class Validator {
             el.visit(new FVVisitor(n));
         }
 
-        private void processSignature(ELNode.Function func) throws WaspException {
-            FunctionInfo funcInfo = func.getFunctionInfo();
+        private void processSignature(ELNode.Function function) throws WaspException {
+            FunctionInfo funcInfo = function.getFunctionInfo();
             String signature = funcInfo.getFunctionSignature();
-            func.setMethodName(getMethod(signature));
-            func.setParameters(getParameters(signature));
+            function.setMethodName(getMethod(signature));
+            function.setParameters(getParameters(signature));
         }
 
         /**
          * Get the return type from the signature.
          */
         private String getReturnType(String signature) throws WaspException {
-
             int start = signature.indexOf(' ');
             if (start < 0) {
                 err.jspError("jsp.error.tld.invalid.signature", signature);
             }
+
             return signature.substring(0, start);
         }
 
@@ -1331,15 +1380,16 @@ class Validator {
          * Get the method name from the signature.
          */
         private String getMethod(String signature) throws WaspException {
-
             int start = signature.indexOf(' ');
             if (start < 0) {
                 err.jspError("jsp.error.tld.invalid.signature", signature);
             }
+
             int end = signature.indexOf('(');
             if (end < 0) {
                 err.jspError("jsp.error.tld.invalid.signature", signature);
             }
+
             return signature.substring(start + 1, end).trim();
         }
 
@@ -1349,8 +1399,8 @@ class Validator {
          * @return An array of parameter class names
          */
         private String[] getParameters(String signature) throws WaspException {
-
             ArrayList<String> params = new ArrayList<>();
+
             // Signature is of the form
             // <return-type> S <method-name S? '('
             // < <arg-type> ( ',' <arg-type> )* )? ')'

--- a/src/main/java/org/glassfish/wasp/runtime/ELContextImpl.java
+++ b/src/main/java/org/glassfish/wasp/runtime/ELContextImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -31,6 +32,11 @@ import jakarta.el.VariableMapper;
  * @author Kin-man Chung
  */
 public class ELContextImpl extends ELContext {
+
+    private FunctionMapper functionMapper;
+    private VariableMapper variableMapper;
+    private ELResolver resolver;
+
     /**
      * Constructs a new ELContext associated with the given ELResolver.
      */
@@ -60,8 +66,4 @@ public class ELContextImpl extends ELContext {
     public VariableMapper getVariableMapper() {
         return variableMapper;
     }
-
-    private FunctionMapper functionMapper;
-    private VariableMapper variableMapper;
-    private ELResolver resolver;
 }

--- a/src/main/java/org/glassfish/wasp/runtime/ELContextWrapper.java
+++ b/src/main/java/org/glassfish/wasp/runtime/ELContextWrapper.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.wasp.runtime;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.EvaluationListener;
+import jakarta.el.FunctionMapper;
+import jakarta.el.ImportHandler;
+import jakarta.el.VariableMapper;
+import jakarta.servlet.jsp.el.NotFoundELResolver;
+
+public class ELContextWrapper extends ELContext {
+
+    private final ELContext wrapped;
+    private final boolean errorOnELNotFound;
+
+    public ELContextWrapper(ELContext wrapped, boolean errorOnELNotFound) {
+        this.wrapped = wrapped;
+        this.errorOnELNotFound = errorOnELNotFound;
+    }
+
+    ELContext getWrappedELContext() {
+        return wrapped;
+    }
+
+    @Override
+    public void setPropertyResolved(boolean resolved) {
+        wrapped.setPropertyResolved(resolved);
+    }
+
+    @Override
+    public void setPropertyResolved(Object base, Object property) {
+        wrapped.setPropertyResolved(base, property);
+    }
+
+    @Override
+    public boolean isPropertyResolved() {
+        return wrapped.isPropertyResolved();
+    }
+
+    @Override
+    public void putContext(Class<?> key, Object contextObject) {
+        wrapped.putContext(key, contextObject);
+    }
+
+    @Override
+    public Object getContext(Class<?> key) {
+        if (key == NotFoundELResolver.class) {
+            return errorOnELNotFound;
+        }
+
+        return wrapped.getContext(key);
+    }
+
+    @Override
+    public ImportHandler getImportHandler() {
+        return wrapped.getImportHandler();
+    }
+
+    @Override
+    public Locale getLocale() {
+        return wrapped.getLocale();
+    }
+
+    @Override
+    public void setLocale(Locale locale) {
+        wrapped.setLocale(locale);
+    }
+
+    @Override
+    public void addEvaluationListener(EvaluationListener listener) {
+        wrapped.addEvaluationListener(listener);
+    }
+
+    @Override
+    public List<EvaluationListener> getEvaluationListeners() {
+        return wrapped.getEvaluationListeners();
+    }
+
+    @Override
+    public void notifyBeforeEvaluation(String expression) {
+        wrapped.notifyBeforeEvaluation(expression);
+    }
+
+    @Override
+    public void notifyAfterEvaluation(String expression) {
+        wrapped.notifyAfterEvaluation(expression);
+    }
+
+    @Override
+    public void notifyPropertyResolved(Object base, Object property) {
+        wrapped.notifyPropertyResolved(base, property);
+    }
+
+    @Override
+    public boolean isLambdaArgument(String name) {
+        return wrapped.isLambdaArgument(name);
+    }
+
+    @Override
+    public Object getLambdaArgument(String name) {
+        return wrapped.getLambdaArgument(name);
+    }
+
+    @Override
+    public void enterLambdaScope(Map<String, Object> arguments) {
+        wrapped.enterLambdaScope(arguments);
+    }
+
+    @Override
+    public void exitLambdaScope() {
+        wrapped.exitLambdaScope();
+    }
+
+    @Override
+    public <T> T convertToType(Object obj, Class<T> type) {
+        return wrapped.convertToType(obj, type);
+    }
+
+    @Override
+    public ELResolver getELResolver() {
+        return wrapped.getELResolver();
+    }
+
+    @Override
+    public FunctionMapper getFunctionMapper() {
+        return wrapped.getFunctionMapper();
+    }
+
+    @Override
+    public VariableMapper getVariableMapper() {
+        return wrapped.getVariableMapper();
+    }
+}

--- a/src/main/java/org/glassfish/wasp/runtime/JspContextWrapper.java
+++ b/src/main/java/org/glassfish/wasp/runtime/JspContextWrapper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -17,6 +18,10 @@
 
 package org.glassfish.wasp.runtime;
 
+import static jakarta.servlet.jsp.tagext.VariableInfo.AT_BEGIN;
+import static jakarta.servlet.jsp.tagext.VariableInfo.AT_END;
+import static jakarta.servlet.jsp.tagext.VariableInfo.NESTED;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -24,6 +29,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.glassfish.wasp.compiler.Localizer;
@@ -42,7 +48,6 @@ import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.el.ExpressionEvaluator;
 import jakarta.servlet.jsp.el.VariableResolver;
 import jakarta.servlet.jsp.tagext.BodyContent;
-import jakarta.servlet.jsp.tagext.VariableInfo;
 
 /**
  * Implementation of a JSP Context Wrapper.
@@ -61,16 +66,16 @@ public class JspContextWrapper extends PageContext {
     private Hashtable<String, Object> pageAttributes;
 
     // ArrayList of NESTED scripting variables
-    private ArrayList<String> nestedVars;
+    private List<String> nestedVars;
 
     // ArrayList of AT_BEGIN scripting variables
-    private ArrayList<String> atBeginVars;
+    private List<String> atBeginVars;
 
     // ArrayList of AT_END scripting variables
-    private ArrayList<String> atEndVars;
+    private List<String> atEndVars;
 
     private Map<String, String> aliases;
-    private HashMap<String, Object> originalNestedVars;
+    private Map<String, Object> originalNestedVars;
     private ELContext elContext;
 
     public JspContextWrapper(JspContext jspContext, ArrayList<String> nestedVars, ArrayList<String> atBeginVars, ArrayList<String> atEndVars,
@@ -95,7 +100,6 @@ public class JspContextWrapper extends PageContext {
 
     @Override
     public Object getAttribute(String name) {
-
         if (name == null) {
             throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
         }
@@ -105,7 +109,6 @@ public class JspContextWrapper extends PageContext {
 
     @Override
     public Object getAttribute(String name, int scope) {
-
         if (name == null) {
             throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
         }
@@ -119,7 +122,6 @@ public class JspContextWrapper extends PageContext {
 
     @Override
     public void setAttribute(String name, Object value) {
-
         if (name == null) {
             throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
         }
@@ -133,7 +135,6 @@ public class JspContextWrapper extends PageContext {
 
     @Override
     public void setAttribute(String name, Object value, int scope) {
-
         if (name == null) {
             throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
         }
@@ -151,30 +152,28 @@ public class JspContextWrapper extends PageContext {
 
     @Override
     public Object findAttribute(String name) {
-
         if (name == null) {
             throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
         }
 
-        Object o = pageAttributes.get(name);
-        if (o == null) {
-            o = invokingJspCtxt.getAttribute(name, REQUEST_SCOPE);
-            if (o == null) {
+        Object attribute = pageAttributes.get(name);
+        if (attribute == null) {
+            attribute = invokingJspCtxt.getAttribute(name, REQUEST_SCOPE);
+            if (attribute == null) {
                 if (getSession() != null) {
-                    o = invokingJspCtxt.getAttribute(name, SESSION_SCOPE);
+                    attribute = invokingJspCtxt.getAttribute(name, SESSION_SCOPE);
                 }
-                if (o == null) {
-                    o = invokingJspCtxt.getAttribute(name, APPLICATION_SCOPE);
+                if (attribute == null) {
+                    attribute = invokingJspCtxt.getAttribute(name, APPLICATION_SCOPE);
                 }
             }
         }
 
-        return o;
+        return attribute;
     }
 
     @Override
     public void removeAttribute(String name) {
-
         if (name == null) {
             throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
         }
@@ -189,7 +188,6 @@ public class JspContextWrapper extends PageContext {
 
     @Override
     public void removeAttribute(String name, int scope) {
-
         if (name == null) {
             throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
         }
@@ -203,7 +201,6 @@ public class JspContextWrapper extends PageContext {
 
     @Override
     public int getAttributesScope(String name) {
-
         if (name == null) {
             throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
         }
@@ -269,25 +266,32 @@ public class JspContextWrapper extends PageContext {
         return invokingJspCtxt.getServletContext();
     }
 
-    static public PageContext getRootPageContext(PageContext pc) {
-        while (pc instanceof JspContextWrapper) {
-            pc = ((JspContextWrapper) pc).invokingJspCtxt;
+    static public PageContext getRootPageContext(PageContext pageContect) {
+        while (pageContect instanceof JspContextWrapper) {
+            pageContect = ((JspContextWrapper) pageContect).invokingJspCtxt;
         }
-        return pc;
+
+        return pageContect;
     }
 
     @Override
     public ELContext getELContext() {
         if (elContext == null) {
-            PageContext pc = invokingJspCtxt;
-            while (pc instanceof JspContextWrapper) {
-                pc = ((JspContextWrapper) pc).invokingJspCtxt;
+            PageContext pageContext = invokingJspCtxt;
+            while (pageContext instanceof JspContextWrapper) {
+                pageContext = ((JspContextWrapper) pageContext).invokingJspCtxt;
             }
-            PageContextImpl pci = (PageContextImpl) pc;
-            elContext = pci.getJspApplicationContext().createELContext(invokingJspCtxt.getELContext().getELResolver());
-            elContext.putContext(jakarta.servlet.jsp.JspContext.class, this);
+
+            PageContextImpl pageContextImpl = (PageContextImpl) pageContext;
+            elContext = pageContextImpl.getJspApplicationContext()
+                                       .createELContext(
+                                           invokingJspCtxt.getELContext()
+                                                          .getELResolver());
+
+            elContext.putContext(JspContext.class, this);
             ((ELContextImpl) elContext).setVariableMapper(new VariableMapperImpl());
         }
+
         return elContext;
     }
 
@@ -354,16 +358,16 @@ public class JspContextWrapper extends PageContext {
      * Synchronize variables before fragment invokation
      */
     public void syncBeforeInvoke() {
-        copyTagToPageScope(VariableInfo.NESTED);
-        copyTagToPageScope(VariableInfo.AT_BEGIN);
+        copyTagToPageScope(NESTED);
+        copyTagToPageScope(AT_BEGIN);
     }
 
     /**
      * Synchronize variables at end of tag file
      */
     public void syncEndTagFile() {
-        copyTagToPageScope(VariableInfo.AT_BEGIN);
-        copyTagToPageScope(VariableInfo.AT_END);
+        copyTagToPageScope(AT_BEGIN);
+        copyTagToPageScope(AT_END);
         restoreNestedVariables();
     }
 
@@ -377,17 +381,17 @@ public class JspContextWrapper extends PageContext {
         Iterator<String> iter = null;
 
         switch (scope) {
-        case VariableInfo.NESTED:
+        case NESTED:
             if (nestedVars != null) {
                 iter = nestedVars.iterator();
             }
             break;
-        case VariableInfo.AT_BEGIN:
+        case AT_BEGIN:
             if (atBeginVars != null) {
                 iter = atBeginVars.iterator();
             }
             break;
-        case VariableInfo.AT_END:
+        case AT_END:
             if (atEndVars != null) {
                 iter = atEndVars.iterator();
             }
@@ -396,10 +400,10 @@ public class JspContextWrapper extends PageContext {
 
         while (iter != null && iter.hasNext()) {
             String varName = iter.next();
-            Object obj = getAttribute(varName);
+            Object attribute = getAttribute(varName);
             varName = findAlias(varName);
-            if (obj != null) {
-                invokingJspCtxt.setAttribute(varName, obj);
+            if (attribute != null) {
+                invokingJspCtxt.setAttribute(varName, attribute);
             } else {
                 invokingJspCtxt.removeAttribute(varName, PAGE_SCOPE);
             }
@@ -415,9 +419,9 @@ public class JspContextWrapper extends PageContext {
             while (iter.hasNext()) {
                 String varName = iter.next();
                 varName = findAlias(varName);
-                Object obj = invokingJspCtxt.getAttribute(varName);
-                if (obj != null) {
-                    originalNestedVars.put(varName, obj);
+                Object attribute = invokingJspCtxt.getAttribute(varName);
+                if (attribute != null) {
+                    originalNestedVars.put(varName, attribute);
                 }
             }
         }
@@ -432,9 +436,9 @@ public class JspContextWrapper extends PageContext {
             while (iter.hasNext()) {
                 String varName = iter.next();
                 varName = findAlias(varName);
-                Object obj = originalNestedVars.get(varName);
-                if (obj != null) {
-                    invokingJspCtxt.setAttribute(varName, obj);
+                Object nestedVar = originalNestedVars.get(varName);
+                if (nestedVar != null) {
+                    invokingJspCtxt.setAttribute(varName, nestedVar);
                 } else {
                     invokingJspCtxt.removeAttribute(varName, PAGE_SCOPE);
                 }
@@ -450,7 +454,6 @@ public class JspContextWrapper extends PageContext {
      * @return The variable name for which varName is used as an alias, or varName if it is not being used as an alias
      */
     private String findAlias(String varName) {
-
         if (aliases == null) {
             return varName;
         }
@@ -459,6 +462,7 @@ public class JspContextWrapper extends PageContext {
         if (alias == null) {
             return varName;
         }
+
         return alias;
     }
 }

--- a/src/main/java/org/glassfish/wasp/runtime/JspSourceDependent.java
+++ b/src/main/java/org/glassfish/wasp/runtime/JspSourceDependent.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -17,6 +18,8 @@
 
 package org.glassfish.wasp.runtime;
 
+import java.util.List;
+
 /**
  * Interface for tracking the source files dependencies, for the purpose of compiling out of date pages. This is used
  * for 1) files that are included by page directives 2) files that are included by include-prelude and include-coda in
@@ -28,5 +31,9 @@ public interface JspSourceDependent {
     /**
      * Returns a list of files names that the current page has a source dependency on.
      */
-    java.util.List<String> getDependants();
+    List<String> getDependants();
+
+    default boolean getErrorOnELNotFound() {
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes #43

Makes sure that if an EL expression can not be resolved an error is
thrown when the corresponding attribute set to true.

`com/sun/ts/tests/jsp/spec/tagfiles/directives/general/URLClient.java#errorOnELNotFoundFalseTest` and related now pass in the TCK.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>