### PR TITLE
[Draft] Update info in org.glassfish.wasp.taglibs.standard.Version class

### DIFF
--- a/src/main/java/org/glassfish/wasp/taglibs/standard/Version.java
+++ b/src/main/java/org/glassfish/wasp/taglibs/standard/Version.java
@@ -55,7 +55,7 @@ public class Version {
      * Name of product
      */
     public static String getProduct() {
-        return "standard-taglib";
+        return "jakarta-tags";
     }
 
     /**
@@ -66,7 +66,7 @@ public class Version {
      * changed.
      */
     public static int getMajorVersionNum() {
-        return 1;
+        return 4;
     }
 
     /**
@@ -74,7 +74,7 @@ public class Version {
      * a new W3C specification. - API or behaviour change. - its designated as a reference release.
      */
     public static int getReleaseVersionNum() {
-        return 2;
+        return 0;
     }
 
     /**


### PR DESCRIPTION
fixes issue #68. I updated the version to match WaSP -- 4.0.0

new output would be: `jakarta-tags 4.0.0` 

However, I'm not sure if this is necessary, and maybe we could remove this class entirely.   Seems unnecessary to track the version here. I'll keep this as a draft for now. 